### PR TITLE
Fix verifyRequest for urls containing array params

### DIFF
--- a/src/BasicShopifyAPI.php
+++ b/src/BasicShopifyAPI.php
@@ -370,6 +370,13 @@ class BasicShopifyAPI implements SessionAware, ClientAware
             // Grab the HMAC, remove it from the params, then sort the params for hashing
             $hmac = $params['hmac'];
             unset($params['hmac']);
+
+            // Convert array values in the params to a string
+            foreach($params as $key => &$value) {
+                if (is_array($value)) {
+                    $value = '["' . implode('", "', $value) . '"]';
+                }
+            }
             ksort($params);
 
             // Encode and hash the params (without HMAC), add the API secret, and compare to the HMAC from params


### PR DESCRIPTION
verifyRequest doesn't work correctly when selecting multiple items from Shopify panel (and using apps menu) as the IDs are lumped together in an array and sent to the app url.

